### PR TITLE
Ensure that the PR is still open

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -23,6 +23,7 @@ jobs:
                       login
                     }
                     maintainerCanModify
+                    state
                   }
                 }
               }
@@ -42,6 +43,12 @@ jobs:
 
               if (pullRequest.headRepositoryOwner.login === 'laravel') {
                 console.log('PR owned by laravel');
+
+                return;
+              }
+
+              if (pullRequest.headRepositoryOwner.state !== 'OPEN') {
+                console.log('PR has already been closed or merged');
 
                 return;
               }


### PR DESCRIPTION
In some situations, especially when a maintainer merge a PR very quickly, this action won't have time to complete.
The PR will merged or closed, and obviously the maintainer won't have modification access anymore.

Cf. https://github.com/laravel/socialite/pull/585 that was merged before being checked for modification access.
cc/ @driesvints 
