### PR TITLE
Auto compile assets workflow

### DIFF
--- a/.github/workflows/compile-assets.yml
+++ b/.github/workflows/compile-assets.yml
@@ -1,0 +1,28 @@
+name: Compile Assets
+
+on:
+  workflow_call:
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Compile assets
+        run: npm run production
+
+      - name: Commit compiled files
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Compile Assets
+          file_pattern: public/


### PR DESCRIPTION
This Workflow will allow repos likes Horizon, Telescope and even the Laravel website to automatically compile assets as production and commit them. This makes sure this is never forgotten and that the compiled files cannot be tampered with. Only the `public/` path where the compiled assets are, is committed. 