### PR TITLE
Replace deprecated set-output syntax in update-changelog.yml workflow

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Extract release date from git tag
         id: release_date
         run: |
-          echo "::set-output name=date::$(git log -1 --date=short --format=%ad '${{ github.event.release.tag_name }}')"
+          echo "date=$(git log -1 --date=short --format=%ad '${{ github.event.release.tag_name }}')" >> $GITHUB_OUTPUT;
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@v1


### PR DESCRIPTION
The `set-output` syntax is deprecated and will stop working on June 1st 2023.[^1]

Update the workflow to use the new syntax using `$GITHUB_OUTPUT`

[^1]: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/