### PR TITLE
[update-changelog] Always convert release_date to UTC

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -22,10 +22,10 @@ jobs:
         id: release_date
         run: |
           # Get UNIX timestamp from git-tag
-          TIMESTAMP_OF_LAST_COMMIT=$(git log -1 --date=unix --format=%ad '${{ github.event.release.tag_name }}');
+          TIMESTAMP_OF_RELEASE_COMMIT=$(git log -1 --date=unix --format=%ad '${{ github.event.release.tag_name }}');
 
           # Convert timestamp to UTC date in Y-m-d format
-          FORMATED_DATE=$(date -u -d @$TIMESTAMP_OF_LAST_COMMIT +%Y-%m-%d)
+          FORMATED_DATE=$(date -u -d @$TIMESTAMP_OF_RELEASE_COMMIT +%Y-%m-%d)
 
           # Make date available to other steps
           echo "date=$(echo $FORMATED_DATE)" >> $GITHUB_OUTPUT;

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -21,7 +21,14 @@ jobs:
       - name: Extract release date from git tag
         id: release_date
         run: |
-          echo "date=$(git log -1 --date=short --format=%ad '${{ github.event.release.tag_name }}')" >> $GITHUB_OUTPUT;
+          # Get UNIX timestamp from git-tag
+          TIMESTAMP_OF_LAST_COMMIT=$(git log -1 --date=unix --format=%ad '${{ github.event.release.tag_name }}');
+
+          # Convert timestamp to UTC date in Y-m-d format
+          FORMATED_DATE=$(date -u -d @$TIMESTAMP_OF_LAST_COMMIT +%Y-%m-%d)
+
+          # Make date available to other steps
+          echo "date=$(echo $FORMATED_DATE)" >> $GITHUB_OUTPUT;
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@v1


### PR DESCRIPTION
This PR updates the `update-changelog.yml` workflow to always convert the date that is attached to a given tag to UTC.

Should resolve issues of "wrong" dates in CHANGELOGs, when the commit attached to a tag was made in a timezone which is ahead of Europe (eg. Australia).