### PR TITLE
Give GITHUB_TOKEN write permission in GitHub Actions Workflows

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -17,6 +17,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # updated files back to the repository.
+      # https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/
+      contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/compile-assets.yml
+++ b/.github/workflows/compile-assets.yml
@@ -14,6 +14,12 @@ jobs:
   compile:
     runs-on: ubuntu-latest
 
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # compiled assets back to the repository.
+      # https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/
+      contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -7,6 +7,12 @@ jobs:
   update:
     runs-on: ubuntu-latest
 
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # updated CHANGELOG back to the repository.
+      # https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/
+      contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
GitHub changed the default permission of the GITHUB_TOKEN in February for all newly created repositories.[^1]

You now have to explicitly give the GITHUB_TOKEN write permissions for `contents`. Otherwise the "stefanzweifel/git-auto-commit-action"-step will fail.

This PR fixes this potential future issue by setting the permission in the workflow files using "stefanzweifel/git-auto-commit-action".

[^1]: https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/