### PR TITLE
[update-changelog] Parse and Linkify Usernames

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -38,6 +38,7 @@ jobs:
           release-notes: ${{ github.event.release.body }}
           latest-version: ${{ github.event.release.tag_name }}
           compare-url-target-revision: ${{ github.event.release.target_commitish }}
+          parse-github-usernames: true
 
       - name: Commit updated CHANGELOG
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
The changelog-updater GitHub Action has received a new experimental feature, to parse and linkify GitHub usernames found in the release notes. (https://github.com/stefanzweifel/changelog-updater-action/pull/36, https://github.com/stefanzweifel/php-changelog-updater/pull/41)

This PR updates the workflow to enable this experimental feature.

---

The logic to find usernames might be a bit naive, as the CLI is basically just looking for words starting with `@` and  converting them to a link ([source](https://github.com/stefanzweifel/php-changelog-updater/blob/802a56a1a814a599e3f1155c889cf93bc7fdec07/app/Actions/ParseAndLinkifyGitHubUsernamesAction.php)), but I think this should work well with the release notes used in the Laravel org.