### PR TITLE
Abort update-changelog workflow if target branch does not match major release version

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -18,6 +18,36 @@ jobs:
           # is not out of date.
           ref: ${{ github.event.release.target_commitish }}
 
+      - name: Check if branch and release match
+        id: guard
+        run: |
+          NUMERIC_VERSION="${RELEASE_TAG_NAME#v}"
+          MAJOR_VERSION="${NUMERIC_VERSION%%.*}"
+          BRANCH_MAJOR_VERSION="${BRANCH%%.*}"
+
+          echo "MAJOR_VERSION=$(echo $MAJOR_VERSION)" >> $GITHUB_OUTPUT;
+          echo "BRANCH_MAJOR_VERSION=$(echo $BRANCH_MAJOR_VERSION)" >> $GITHUB_OUTPUT;
+
+          if [ "$MAJOR_VERSION" != "$BRANCH_MAJOR_VERSION" ]; then
+            echo "Mismatched versions! Aborting."
+            VERSION_MISMATCH='true';
+            # exit 1
+          else
+            echo "Versions match! Proceeding."
+            VERSION_MISMATCH='false';
+          fi
+          echo "VERSION_MISMATCH=$(echo $VERSION_MISMATCH)" >> $GITHUB_OUTPUT;
+        env:
+          BRANCH: ${{ github.event.release.target_commitish }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+
+      - name: Fail if branch and release tag do not match
+        if: ${{ steps.guard.outputs.VERSION_MISMATCH == 'true' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+              core.setFailed('Workflow failed. Release version does not match with selected target branch. Changelog not updated automatically.')
+
       - name: Extract release date from git tag
         id: release_date
         run: |

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -19,6 +19,7 @@ jobs:
           ref: ${{ github.event.release.target_commitish }}
 
       - name: Check if branch and release match
+        if: ${{ github.event.release.target_commitish != 'main' && github.event.release.target_commitish != 'master' }}
         id: guard
         run: |
           NUMERIC_VERSION="${RELEASE_TAG_NAME#v}"
@@ -31,7 +32,6 @@ jobs:
           if [ "$MAJOR_VERSION" != "$BRANCH_MAJOR_VERSION" ]; then
             echo "Mismatched versions! Aborting."
             VERSION_MISMATCH='true';
-            # exit 1
           else
             echo "Versions match! Proceeding."
             VERSION_MISMATCH='false';


### PR DESCRIPTION
This PR adds two new steps to the update-changelog.yml workflow to prevent the workflow from adding release notes to the wrong changelog file. (Adding release notes for v9.52.12 to changelog for `v10.x`)

In detail, these new steps validate if the given release version (eg. `v10.1.2`) matches with the selected target branch (eg. `10.x`).

The script extracts the major version from both strings by using parameter expansion in Bash. The `v` is being removed from the given release version (resulting in `10.1.2`). Next the major version is extracted by ignoring all values after the first dot (resulting in `10`).

The major version is also extracted from the selected target branch by ignoring all values after the first dot (resulting in `10`).

If the two major version do not match the second step is being executed, a `VERSION_MISMATCH` output variable is set to true.

If that value is true, the entire workflow fails by using the [`actions/github-script`-Action]( https://github.com/actions/toolkit/tree/main/packages/core#exit-codes).

The GitHub user triggering the workflow should receive a notification by mail and see the error message on the summary screen of the Workflow run.

<img width="954" alt="Screenshot 2023-08-24 at 20 16 06" src="https://github.com/laravel/.github/assets/1080923/fe94bdf4-9347-4911-9827-b441abd04aba">

---

## Requirements

- Release name must follow semantic versioning (eg `v10.21.0`, `v1.0.0`)
- Target branch must be numeric (eg `10.x`, `1.x`, `2.x`)
    - Guard is ignored if branch name is either `main` or `master` (see https://github.com/laravel/.github/pull/13/commits/1fe1ee530607600641673c4e0a3a6f45e6a5f421)

~~The workflow currently fails if the target branch of a release is a default branch like `main` or `master`. (The workflow could be updated so that the _guard_ is not executed in those cases)~~