### PR TITLE
Automate message about draft PR's

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -60,7 +60,7 @@ jobs:
                   issue_number: pullNumber,
                   owner: 'laravel',
                   repo: context.repo.repo,
-                  body: "Thanks for submitting a PR!\n\nNote that draft PR's are not reviewed. If you would like a review, please mark your pull request as ready for review in the GitHub user interface.\n\nIf your pull request remains in draft for too long, we may close it due to inactivity."
+                  body: "Thanks for submitting a PR!\n\nNote that draft PR's are not reviewed. If you would like a review, please mark your pull request as ready for review in the GitHub user interface.\n\nPull requests that are abandoned in draft may be closed due to inactivity."
                 });
               }
             } catch(e) {

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -6,6 +6,67 @@ on:
   workflow_call:
 
 jobs:
+  draft:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const repo = context.repo.repo;
+          
+            const query = `
+              query($number: Int!) {
+                repository(owner: "laravel", name: "${repo}") {
+                  pullRequest(number: $number) {
+                    headRepositoryOwner {
+                      login
+                    }
+                    isDraft
+                    state
+                  }
+                }
+              }
+            `;
+
+            const pullNumber = context.issue.number;
+            const variables = { number: pullNumber };
+
+            try {
+              console.log(`Check is pull request is submitted as draft ...`);
+
+              const result = await github.graphql(query, variables);
+
+              console.log(JSON.stringify(result, null, 2));
+
+              const pullRequest = result.repository.pullRequest;
+
+              if (pullRequest.headRepositoryOwner.login === 'laravel') {
+                console.log('PR owned by laravel');
+
+                return;
+              }
+
+              if (pullRequest.state !== 'OPEN') {
+                console.log('PR has already been closed or merged');
+
+                return;
+              }
+
+              if (pullRequest.isDraft) {
+                console.log('PR not owned by Laravel and is submitted as a draft');
+
+                await github.rest.issues.createComment({
+                  issue_number: pullNumber,
+                  owner: 'laravel',
+                  repo: context.repo.repo,
+                  body: "Thanks for submitting a PR!\n\nPlease note that draft PR's are not reviewed. If you'd like a review, please mark your pull request as ready in the GitHub user interface.\n\nShould your pull request remain a draft for too long, we may close it due to inactivity."
+                });
+              }
+            } catch(e) {
+              console.log(e);
+            }
+
   uneditable:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -33,7 +33,7 @@ jobs:
             const variables = { number: pullNumber };
 
             try {
-              console.log(`Check is pull request is submitted as draft ...`);
+              console.log(`Determine if pull request is submitted as draft ...`);
 
               const result = await github.graphql(query, variables);
 
@@ -48,19 +48,19 @@ jobs:
               }
 
               if (pullRequest.state !== 'OPEN') {
-                console.log('PR has already been closed or merged');
+                console.log('PR has already been closed or merged.');
 
                 return;
               }
 
               if (pullRequest.isDraft) {
-                console.log('PR not owned by Laravel and is submitted as a draft');
+                console.log('PR not owned by Laravel and is submitted as a draft.');
 
                 await github.rest.issues.createComment({
                   issue_number: pullNumber,
                   owner: 'laravel',
                   repo: context.repo.repo,
-                  body: "Thanks for submitting a PR!\n\nPlease note that draft PR's are not reviewed. If you'd like a review, please mark your pull request as ready in the GitHub user interface.\n\nShould your pull request remain a draft for too long, we may close it due to inactivity."
+                  body: "Thanks for submitting a PR!\n\nNote that draft PR's are not reviewed. If you would like a review, please mark your pull request as ready for review in the GitHub user interface.\n\nIf your pull request remains in draft for too long, we may close it due to inactivity."
                 });
               }
             } catch(e) {


### PR DESCRIPTION
One of the things we currently experience the most with PR's is that people submit them as draft but don't realise their PR won't get reviewed.

This new automated GitHub Action will post a message when a user submits their PR as a draft so they're aware they'll need to mark it as ready when they want a review. This also saves us the manual task of doing that all the time.