### PR TITLE
Allow build path to be customised

### DIFF
--- a/.github/workflows/compile-assets.yml
+++ b/.github/workflows/compile-assets.yml
@@ -9,6 +9,9 @@ on:
       cmd:
         default: "production"
         type: string
+      build_path:
+        default: "public/"
+        type: string
 
 jobs:
   compile:
@@ -32,4 +35,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Compile Assets
-          file_pattern: public/
+          file_pattern: ${{ inputs.build_path }}


### PR DESCRIPTION
With Pulse we build to the `/dist` directory. Would be good to allow this to be customised.

See: https://github.com/laravel/pulse/pull/278