### PR TITLE
fail fast is not necessary as only on job

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,9 +7,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: true
-
     name: Static Analysis
 
     steps:


### PR DESCRIPTION
The action is contained in one job - therefore the fail-fast is not doing anything & fail-fast=true is default anyway

![image](https://github.com/user-attachments/assets/b1a67422-ebf8-4396-b9cf-9d5e1659ccd1)
