### PR TITLE
Use latest LTS version of node.

### DIFF
--- a/.github/workflows/compile-assets.yml
+++ b/.github/workflows/compile-assets.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       node:
-        default: "16"
+        default: "lts/*"
         type: string
       cmd:
         default: "production"


### PR DESCRIPTION
If you need to pin back down to version 16, you may add the following to your action:

```diff
name: Compile Assets

on: [push]

jobs:
  compile:
    uses: laravel/.github/.github/workflows/compile-assets.yml@main
+   with:
+     node: '16'
```