### PR TITLE
Add a workflow to normalize every `composer.json` files in a repository

### DIFF
--- a/.github/workflows/normalize-composer.yml
+++ b/.github/workflows/normalize-composer.yml
@@ -1,4 +1,4 @@
-name: normalize every composer.json files
+name: Normalize every composer.json file
 
 on:
   workflow_call:

--- a/.github/workflows/normalize-composer.yml
+++ b/.github/workflows/normalize-composer.yml
@@ -1,4 +1,4 @@
-name: Normalize every composer.json file
+name: normalize composer.json files
 
 on:
   workflow_call:
@@ -7,7 +7,7 @@ on:
         default: "8.4"
         type: string
       message:
-        default: Normalize every composer.json file
+        default: Normalize composer.json files
         type: string
       fix:
         default: true

--- a/.github/workflows/normalize-composer.yml
+++ b/.github/workflows/normalize-composer.yml
@@ -29,7 +29,7 @@ jobs:
           extensions: json, dom, curl, libxml, mbstring
           coverage: none
 
-      - name: Normalize every composer.json files
+      - name: Normalize every composer.json file
         run: find . -path "*/vendor" -prune -o -name "composer.json" -print -exec composer normalize {} \;
 
       - name: Commit linted files

--- a/.github/workflows/normalize-composer.yml
+++ b/.github/workflows/normalize-composer.yml
@@ -7,7 +7,7 @@ on:
         default: "8.4"
         type: string
       message:
-        default: Normalize every composer.json files
+        default: Normalize every composer.json file
         type: string
       fix:
         default: true

--- a/.github/workflows/normalize-composer.yml
+++ b/.github/workflows/normalize-composer.yml
@@ -1,0 +1,39 @@
+name: normalize every composer.json files
+
+on:
+  workflow_call:
+    inputs:
+      php:
+        default: "8.4"
+        type: string
+      message:
+        default: Normalize every composer.json files
+        type: string
+      fix:
+        default: true
+        type: boolean
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php }}
+          tools: composer:v2, composer-normalize
+          extensions: json, dom, curl, libxml, mbstring
+          coverage: none
+
+      - name: Normalize every composer.json files
+        run: find . -path "*/vendor" -prune -o -name "composer.json" -print -exec composer normalize {} \;
+
+      - name: Commit linted files
+        if: ${{ inputs.fix }}
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: ${{ inputs.message }}


### PR DESCRIPTION
This PR adds a workflow to normalize every `composer.json` files within a repository. I already use it for maintaining https://github.com/SocialiteProviders and this is pretty convenient to enforce consistancy over many `composer.json` files.

Of course, the `vendor` directory is excluded.

To test it manually before merging this PR:
```sh
composer global require ergebnis/composer-normalize
find . -path "*/vendor" -prune -o -name "composer.json" -print -exec composer normalize {} \;
git diff
```

It is achieved using https://github.com/ergebnis/composer-normalize, for which @taylorotwell had a one-liner feedback

![image](https://github.com/user-attachments/assets/e2851367-735f-4faf-aeae-7d29cfa158a5)

---

**Note:** 
this is cool, but what could be even cooler would be receiving a Laravel Cloud early access this weekend 🙏 , kind of Christmas before Christmas 🎄 ?
