### PR TITLE
bump action versions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/compile-assets.yml
+++ b/.github/workflows/compile-assets.yml
@@ -19,9 +19,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node }}
 

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Add comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const repo = context.repo.repo;
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const repo = context.repo.repo;

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -22,7 +22,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 5

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch entire history of repository to ensure release date can be
           # extracted from commit of the given tag.

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Fail if branch and release tag do not match
         if: ${{ steps.guard.outputs.VERSION_MISMATCH == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
               core.setFailed('Workflow failed. Release version does not match with selected target branch. Changelog not updated automatically.')


### PR DESCRIPTION
Noticed a few deprecation in various repos that use these, such as : https://github.com/laravel/agent-detector/actions/runs/25056180870

This PR bumps a whole bunch of action versions: 

- actions/checkout from v4 to v6
- setup-node from v4 to v6
- peter-evans/create-or-update-comment v4 to v5
- actions/github-script v7 to v9 
- nick-fields/retry v3 to v4  


The only potential breaking change was with[ `actions/github-script`](https://github.com/actions/github-script#breaking-changes), but you don't use `require('@actions/github') ` or `getOctokit` in the scripts etc, so all is good!   

I can split this up into seperate prs, if you prefer, but also guessed it wasn't worth the spam.

