### PR TITLE
Tighten pull-requests workflow to least-privilege permissions

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
Follow-up to the GitHub Actions hardening work.

The `pull-requests.yml` workflow only ever operates on pull requests (comment + close), which requires `pull-requests: write`. The `issues: write` scope was redundant, so this removes it to keep the workflow at least-privilege.