### PR TITLE
Remove unused scopes from issues and pull-requests workflows

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -4,9 +4,7 @@ on:
   workflow_call:
 
 permissions:
-  contents: read
   issues: write
-  pull-requests: write
 
 jobs:
   help-wanted:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -6,7 +6,6 @@ on:
   workflow_call:
 
 permissions:
-  contents: read
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
These two reusable workflows declare permission scopes that none of their steps actually use, which both over-grants and breaks calling repositories.

Neither workflow checks out the repository; each runs a single `actions/github-script`/comment step:

- `pull-requests.yml` reads PR metadata via GraphQL and comments on / closes PRs — needs only `pull-requests: write`. The declared `contents: read` is unused.
- `issues.yml` comments on a labeled issue — needs only `issues: write`. The declared `contents: read` and `pull-requests: write` are unused.

Because a reusable workflow may not request more permission than its caller grants, these extra declarations caused `startup_failure` ("requesting 'contents: read', but is only allowed 'contents: none'") in caller repositories whose workflows grant only the scope they actually need.

This trims both to least-privilege. Callers that grant `pull-requests: write` / `issues: write` (their correct minimal scope) then work without needing to grant unused scopes.