### PR TITLE
Scope Dependabot auto-merge to github_actions only

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,8 +19,8 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
-      - name: Auto-merge patch & minor updates
-        if: ${{ contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
+      - name: Auto-merge patch & minor github-actions updates
+        if: ${{ steps.metadata.outputs.package-ecosystem == 'github_actions' && contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Restricts auto-merge to the `github_actions` ecosystem so only Actions patch/minor bumps merge automatically; composer/npm/pip and other Dependabot PRs stay open for review. Majors still stay open.