### PR TITLE
Squash-merge Dependabot github-actions PRs directly

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,9 +19,9 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
-      - name: Auto-merge patch & minor github-actions updates
+      - name: Squash-merge patch & minor github-actions updates
         if: ${{ steps.metadata.outputs.package-ecosystem == 'github_actions' && contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaces `gh pr merge --auto` with an immediate `gh pr merge --squash`. Avoids requiring the per-repo "Allow auto-merge" setting; the workflow squash-merges grouped github-actions patch/minor PRs directly. Majors and other ecosystems stay open.